### PR TITLE
Initialized nodes, blockmap and reject for MapEditor

### DIFF
--- a/mapedit.py
+++ b/mapedit.py
@@ -149,6 +149,9 @@ class MapEditor:
             self.things   = []
             self.segs     = []
             self.ssectors = []
+            self.nodes    = []
+            self.blockmap = []
+            self.reject   = []
 
     def _unpack_lump(self, class_, data):
         s = class_._fmtsize


### PR DESCRIPTION
the nodes, reject and blockmap were not being initialized when creating
a MapEditor without using from_lumps, but using to_lumps requires them
to be initialized. This fix initializes them correctly.
