### PR TITLE
Initialized nodes, blockmap and reject for MapEditor

### DIFF
--- a/mapedit.py
+++ b/mapedit.py
@@ -149,9 +149,9 @@ class MapEditor:
             self.things   = []
             self.segs     = []
             self.ssectors = []
-            self.nodes    = []
-            self.blockmap = []
-            self.reject   = []
+            self.nodes    = Lump("")
+            self.blockmap = Lump("")
+            self.reject   = Lump("")
 
     def _unpack_lump(self, class_, data):
         s = class_._fmtsize


### PR DESCRIPTION
Another fix for nodes/blockmap/reject. Turns out even after making sure they get written to lumps correctly.... they don't write to a file correctly.

Is this possibly an issue with either wadio or even to_lumps()?

It does however, all work correctly with this version, I can generate a map and open it with doombuilder.
