### PR TITLE
Fix Python on 64-bit: stop using long type.

### DIFF
--- a/mapedit.py
+++ b/mapedit.py
@@ -13,8 +13,8 @@ Vertex = make_struct(
 
 GLVertex = make_struct(
   "GLVertex", """Represents a map GL vertex""",
-  [["x", "l", 0],
-   ["y", "l", 0]]
+  [["x", "i", 0],
+   ["y", "i", 0]]
 )
 
 Sidedef = make_struct(

--- a/txdef.py
+++ b/txdef.py
@@ -6,10 +6,10 @@ TextureDef = make_struct(
   "TextureDef",
   """Class for texture definitions""",
   [["name",     '8s', "-"],
-   ["dummy1",   'l',  0  ],
+   ["dummy1",   'i',  0  ],
    ["width",    'h',  0  ],
    ["height",   'h',  0  ],
-   ["dummy2",   'l',  0  ],
+   ["dummy2",   'i',  0  ],
    ["npatches", 'h',  0  ]],
   init_exec = "self.patches = []"
 )
@@ -62,8 +62,8 @@ class Textures(OrderedDict):
 
         # Unpack TEXTURE1
         data = texture1.data
-        numtextures = unpack('l', data[0:4])[0]
-        pointers = unpack('l'*numtextures, data[4:4+numtextures*4])
+        numtextures = unpack('i', data[0:4])[0]
+        pointers = unpack('i'*numtextures, data[4:4+numtextures*4])
         for ptr in pointers:
             texture = TextureDef(bytes=data[ptr:ptr+22])
             for pptr in range(ptr+22, ptr+22+10*texture.npatches, 10):

--- a/util.py
+++ b/util.py
@@ -200,11 +200,11 @@ def pack16(n):
 
 def unpack32(s):
     """Convert a packed signed long (4 bytes) to a Python int"""
-    return unpack('l', s)[0]
+    return unpack('i', s)[0]
 
 def pack32(n):
     """Convert a Python int to a packed signed long (4 bytes)"""
-    return pack('l', n)
+    return pack('i', n)
 
 
 #----------------------------------------------------------------------

--- a/wadio.py
+++ b/wadio.py
@@ -5,15 +5,15 @@ Header = make_struct(
   "Header",
   """Class for WAD file headers""",
   [["type",    '4s', "PWAD"],
-   ["dir_len", 'l',  0     ],
-   ["dir_ptr", 'l',  12    ]]
+   ["dir_len", 'i',  0     ],
+   ["dir_ptr", 'i',  12    ]]
 )
 
 Entry = make_struct(
   "Entry",
   """Class for WAD entries""",
-  [["ptr",       'l',  0 ],
-   ["size",      'l',  0 ],
+  [["ptr",       'i',  0 ],
+   ["size",      'i',  0 ],
    ["name",      '8s', ""],
    ["been_read", 'x',  False]]   # Used by WAD loader
 )


### PR DESCRIPTION
The Python struct library has 'i' (int) and 'l' (long) types that
on 32-bit systems are equivalent. But 'l' is 64-bit on 64-bit
systems and this breaks WAD parsing. So switch to using 'i' which
is always 32-bit.
