### PR TITLE
fixed misuse of os.path.splitext

### DIFF
--- a/lump.py
+++ b/lump.py
@@ -241,7 +241,7 @@ class Graphic(Lump):
         respectively. However, .raw ignores this parameter and always
         writes in palette mode."""
 
-        format = os.path.splitext(filename)[1:].upper()
+        format = os.path.splitext(filename)[1:][0].replace('.', '').upper()
         if   format == 'LMP': writefile(filename, self.data)
         elif format == 'RAW': writefile(filename, self.to_raw())
         else:


### PR DESCRIPTION
fixed misuse (crash) of os.path.splitext: slicing the tuple it returns results in a tuple, not a string
