### PR TITLE
New demo: generates flats and textures for each Palette entry

### DIFF
--- a/demo/blocky.py
+++ b/demo/blocky.py
@@ -39,5 +39,8 @@ for i in range(0,256):
     flat.load_raw(bytes([i])*4096)
     out.flats[name] = flat
 
+# fix flats in vanilla
+out.flats.prefix='FF*_START'
+
 out.txdefs = editor.to_lumps()
 out.to_file('out.wad')

--- a/demo/blocky.py
+++ b/demo/blocky.py
@@ -7,8 +7,9 @@ from omg import *
 from omg.txdef import *
 import struct
 
+iwad = WAD('doom2.wad')
 out  = WAD()
-editor = omg.txdef.Textures()
+editor = omg.txdef.Textures(iwad.txdefs)
 
 for i in range(0,256):
 

--- a/demo/blocky.py
+++ b/demo/blocky.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+# generates a PWAD with 256 64x64-sized flat color patches and textures named
+# COLORXXX and 256 flats named FOLORXXX where XXX is a decimal index into the
+# palette
+
+from omg import *
+from omg.txdef import *
+import struct
+
+out  = WAD()
+editor = omg.txdef.Textures()
+
+for i in range(0,256):
+
+    # generate raw patch data for palette index i
+    topdelta = 0
+    length = 64
+    unused = 0
+    data = i
+    post = struct.pack('<BBB64sB', topdelta, length, unused, bytes([data])*64, unused)
+    width = height = 64
+    leftoffs = topoffs = 0
+    postoffs = 264
+    patch = struct.pack('<HHhh', width, height, leftoffs, topoffs) \
+            + struct.pack('<L', postoffs) * 64 \
+            + post
+    gr = Graphic()
+    gr.data = patch
+    name = "COLOR{:03d}".format(i)
+    out.patches[name] = gr
+
+    # generate a texture entry
+    editor.simple(name, out.patches[name])
+
+    # generate a flat
+    name = "FOLOR{:03d}".format(i)
+    flat = Flat()
+    flat.load_raw(bytes([i])*4096)
+    out.flats[name] = flat
+
+out.txdefs = editor.to_lumps()
+out.to_file('out.wad')

--- a/demo/blocky.py
+++ b/demo/blocky.py
@@ -15,11 +15,12 @@ for i in range(0,256):
 
     # generate raw patch data for palette index i
     topdelta = 0
-    length = 64
+    length = 128
     unused = 0
     data = i
-    post = struct.pack('<BBB64sB', topdelta, length, unused, bytes([data])*64, unused)
-    width = height = 64
+    post = struct.pack('<BBB{}sB'.format(length), topdelta, length, unused, bytes([data])*length, unused)
+    width = 64
+    height = 128
     leftoffs = topoffs = 0
     postoffs = 264
     patch = struct.pack('<HHhh', width, height, leftoffs, topoffs) \


### PR DESCRIPTION
Generates a PWAD with 256 patches, 256 corresponding texture
definitions, and 256 flats; each named COLORxyz or FOLORxyz,
where xyz is a decimal index into the palette (000-255), and
the corresponding texture (or flat) is a solid 64x64 block of
that palette colour.

Depends upon PR #37.