### PR TITLE
Fix missing self to access linedefs instance variable

### DIFF
--- a/omg/mapedit.py
+++ b/omg/mapedit.py
@@ -349,7 +349,7 @@ class MapEditor:
         m["_HEADER_"] = self.header
         m["VERTEXES"] = Lump(join([x.pack() for x in self.vertexes]))
         m["THINGS"  ] = Lump(join([x.pack() for x in self.things  ]))
-        m["LINEDEFS"] = Lump(join([x.pack() for x in linedefs     ]))
+        m["LINEDEFS"] = Lump(join([x.pack() for x in self.linedefs]))
         m["SIDEDEFS"] = Lump(join([x.pack() for x in self.sidedefs]))
         m["SECTORS" ] = Lump(join([x.pack() for x in self.sectors ]))
         m["NODES"]    = Lump(join([x.pack() for x in self.nodes   ]))


### PR DESCRIPTION
Fixes the following error 

```
  File ".....\omg\mapedit.py", line 352, in to_lumps
    m["LINEDEFS"] = Lump(join([x.pack() for x in linedefs     ]))
NameError: name 'linedefs' is not defined. Did you mean: 'Linedef'?
```